### PR TITLE
Added telemetry recording

### DIFF
--- a/Config/MFD/SLG.cfg
+++ b/Config/MFD/SLG.cfg
@@ -12,15 +12,15 @@ local function eng_format(value)
     if value == 0 then
         return "0.000  "
     end
-    
+
     local sign = value < 0 and "-" or " "
     local abs_value = math.abs(value)
-    
+
     -- Engineering exponent (multiple of 3)
     local log_val = math.log10(abs_value)
     local exponent = math.floor(log_val / 3) * 3
     local scaled = abs_value / (10 ^ exponent)
-    
+
     -- Safety clamp for floating-point edge cases (e.g. 999.999999 → 1.000 k)
     if scaled >= 1000 then
         scaled = scaled / 1000
@@ -29,9 +29,9 @@ local function eng_format(value)
         scaled = scaled * 1000
         exponent = exponent - 3
     end
-    
+
     local formatted = string.format("%7.3f", scaled)
-    
+
     -- Full metric prefixes (positive & negative)
     local prefixes = {
         [24] = "Y", [21] = "Z", [18] = "E", [15] = "P", [12] = "T",
@@ -47,13 +47,13 @@ end
 
 
 -- Button labels (12 slots, left + right MFD buttons)
-local btn_label = {"RGD", "THR", "", "", "", "", "", "", "", "", "", "CLR"}
+local btn_label = {"RGD", "THR", "TLM", "", "", "", "", "", "", "", "", "CLR"}
 
 -- Button menu (shown when you press the SEL button on the MFD)
 local btn_menu = {
   {l1='RGD', sel=''},
   {l1='THR', sel=''},
-  {l1='', sel=''},
+  {l1='TLM', sel=''},
   {l1='', sel=''},
   {l1='', sel=''},
   {l1='', sel=''},
@@ -70,7 +70,7 @@ end
 
 ---callback
 function buttonmenu()
-  return btn_menu, 2
+  return btn_menu, 3
 end
 
 local VERNIER_THRUST = 463
@@ -140,13 +140,53 @@ local self={
   ta_imp =nil,
   M      =nil,
   Mimp   =nil,
-  epoch  =nil,
-  tgo_imp=nil,--time from now to impact, should always be positive
-  fpa_imp=nil,--impact flight path angle, should be negative and often close to -90deg
-  v_imp  =nil,--inertial speed at impact, should be positive
+  epoch  =0.0,
+  tgo_imp=0.0,--time from now to impact, should always be positive
+  fpa_imp=0.0,--impact flight path angle, should be negative and often close to -90deg
+  v_imp  =0.0,--inertial speed at impact, should be positive
   --vessel interface
-  vi = vessel.get_focusinterface()
+  vi = vessel.get_focusinterface(),
+  --telemetry recording
+  tlm_active=false,
+  ouf=nil
 }
+
+local function record_tlm()
+    self.ouf:write(oapi.get_simtime()..","..
+                   (self.slant or "nil")..","..
+                   (self.vel_b.x or "nil")..","..
+                   (self.vel_b.y or "nil")..","..
+                   (self.vel_b.z or "nil")..","..
+                   (self.alt or "nil")..","..
+                   (self.r or "nil")..","..
+                   (self.r_topo or "nil")..","..
+                   (self.rate.x or "nil")..","..
+                   (self.rate.y or "nil")..","..
+                   (self.rate.z or "nil")..","..
+                   (self.slant_factor or "nil")..","..
+                   (self.mu or "nil")..","..
+                   (self.g or "nil")..","..
+                   (self.ta or "nil")..","..
+                   (self.ta_imp or "nil")..","..
+                   (self.M or "nil")..","..
+                   (self.Mimp or "nil")..","..
+                   (self.epoch or "nil")..","..
+                   (self.tgo_imp or "nil")..","..
+                   (self.fpa_imp or "nil")..","..
+                   (self.v_imp or "nil").."\n")
+end
+
+
+local function open_tlm()
+    --
+    self.ouf = io.open("slg_tlm.csv", "w")
+    self.ouf:write("simt,slant,vel_b.x,vel_b.y,vel_b.z,alt,r,r_topo,rate.x,rate.y,rate.z,slant_factor,mu,g,ta,ta_imp,M,Mimp,epoch,tgo_imp,fpa_imp,v_imp\n")
+end
+
+
+local function close_tlm()
+    self.ouf:close()
+end
 
 local function DX(x, scale)
   if scale == 1 then
@@ -328,11 +368,16 @@ function update(skp)
   else
     skp:text(cw*1, ch*14, "Auto Throttle       disabled")
   end  
+  if self.tlm_active then
+    skp:text(cw*1, ch*15, "Telemetry           ENABLED")
+  else
+    skp:text(cw*1, ch*15, "Telemetry           disabled")
+  end
 
   calc_impact()
-  skp:text(cw*1, ch*15, "Impact TGo:  "..eng_format(self.tgo_imp).."s");
-  skp:text(cw*1, ch*16, "       fpa:  "..eng_format(self.fpa_imp*DEG).."\176");
-  skp:text(cw*1, ch*17, "       v:    "..eng_format(self.v_imp).."m/s")
+  skp:text(cw*1, ch*16, "Impact TGo:  "..eng_format(self.tgo_imp).."s");
+  skp:text(cw*1, ch*17, "       fpa:  "..eng_format(self.fpa_imp*DEG).."\176");
+  skp:text(cw*1, ch*18, "       v:    "..eng_format(self.v_imp).."m/s")
   return true
 end
 
@@ -494,10 +539,13 @@ local function auto_sequence(simt)
 end
 
 ---callback
-function prestep(simt,simdt,mjd)
-  navigate()  
-  steer_retro()
-  auto_sequence(simt)
+function prestep(simt, simdt, mjd)
+    navigate()
+    steer_retro()
+    auto_sequence(simt)
+    if self.tlm_active then
+        record_tlm()
+    end
 end
 
 -- Handle button presses
@@ -515,6 +563,14 @@ function consumebutton(bt, event)
     self.auto_throttle=not self.auto_throttle
     self.vi:set_thrustergrouplevel(THGROUP.MAIN,0)
 
+    return true
+  elseif bt == 2 and event%PANEL_MOUSE.LBPRESSED == PANEL_MOUSE.LBDOWN then
+    self.tlm_active=not self.tlm_active
+    if self.tlm_active then
+        open_tlm()
+    else
+        close_tlm()
+    end
     return true
   elseif bt == 11 and event%PANEL_MOUSE.LBPRESSED == PANEL_MOUSE.LBDOWN then
     -- CLR button: just refresh


### PR DESCRIPTION
Added a button that enables telemetry, and added code which prints much of the internal state of the MFD on each frame. Warning, this can generate multiple megabytes of output per landing attempt.