### PR TITLE
Updated sequence engine

### DIFF
--- a/Config/MFD/SLG.cfg
+++ b/Config/MFD/SLG.cfg
@@ -75,7 +75,7 @@ end
 
 local VERNIER_THRUST = 463
 local MAX_RETRO_THR=43757
-local AltMark=92000
+local AltMark=94000
 
 local DescentCurveSpd={ 1.5, 3, 30, 120,  210,  250};
 local DescentCurveAlt={13.0,15,300,4000,13000,20000};
@@ -90,8 +90,8 @@ local STATE={
   WAITING_FOR_ALT_MARK=1,
   WAITING_FOR_PRERETRO=2,
   PRERETRO=3,
-  RETRO_WAIT_FOR_THRUST=4,
-  RETRO_WAIT_FOR_BURNOUT = 5,
+  RETRO=4,
+  RETRO_WATCH_FOR_BURNOUT = 5,
   RETRO_WAIT_FOR_JETTISON = 6,
   WAIT_FOR_DROP_TO_CURVE=7,
   DROP_TO_CURVE=8,
@@ -105,8 +105,8 @@ local STATE_NAME={
   [STATE.WAITING_FOR_ALT_MARK]="Waiting for altitude mark",
   [STATE.WAITING_FOR_PRERETRO]="Have Alt Mark, waiting for preretro",
   [STATE.PRERETRO]            ="Pre-retro, starting verniers",
-  [STATE.RETRO_WAIT_FOR_THRUST]="Retro - wait for thrust >4g",
-  [STATE.RETRO_WAIT_FOR_BURNOUT] = "Retro - wait for thrust <3.5g",
+  [STATE.RETRO]="Retro - Mainstage",
+  [STATE.RETRO_WATCH_FOR_BURNOUT] = "Retro - wait for thrust <3.5g",
   [STATE.RETRO_WAIT_FOR_JETTISON] = "Retro - wait for jettison",
   [STATE.WAIT_FOR_DROP_TO_CURVE]="Post-retro, stabilize",
   [STATE.DROP_TO_CURVE]       ="Drop to descent curve",
@@ -158,6 +158,13 @@ local self={
   ouf=nil
 }
 
+local function get_thr_acc()
+    local mass = self.vi:get_mass()
+    local thrust = self.vi:get_thrustergrouplevel(THGROUP.MAIN) * 3 * VERNIER_THRUST +
+                   self.vi:get_thrustergrouplevel(THGROUP.HOVER) * MAX_RETRO_THR
+    return thrust / mass
+end
+
 local function record_tlm()
     self.ouf:write(oapi.get_simtime()..","..
                    (self.slant or "nil")..","..
@@ -180,6 +187,8 @@ local function record_tlm()
                    (self.epoch or "nil")..","..
                    (self.tgo_imp or "nil")..","..
                    (self.fpa_imp or "nil")..","..
+                   (STATE_NAME[self.sequence])..","..
+                   (get_thr_acc() or "nil")..","..
                    (self.v_imp or "nil").."\n")
 end
 
@@ -187,7 +196,7 @@ end
 local function open_tlm()
     --
     self.ouf = io.open("slg_tlm.csv", "w")
-    self.ouf:write("simt,slant,vel_b.x,vel_b.y,vel_b.z,alt,r,r_topo,rate.x,rate.y,rate.z,slant_factor,mu,g,ta,ta_imp,M,Mimp,epoch,tgo_imp,fpa_imp,v_imp\n")
+    self.ouf:write("simt,slant,vel_b.x,vel_b.y,vel_b.z,alt,r,r_topo,rate.x,rate.y,rate.z,slant_factor,mu,g,ta,ta_imp,M,Mimp,epoch,tgo_imp,fpa_imp,seq,thr_acc,v_imp\n")
 end
 
 
@@ -304,13 +313,6 @@ local function calc_impact()
   self.fpa_imp=-math.atan2(sfpaImp,cfpaImp);
   self.tgo_imp=(self.MImp-self.M)/n;
 
-end
-
-local function get_thr_acc()
-    local mass = self.vi:get_mass()
-    local thrust = self.vi:get_thrustergrouplevel(THGROUP.MAIN) * 3 * VERNIER_THRUST +
-                   self.vi:get_thrustergrouplevel(THGROUP.HOVER) * MAX_RETRO_THR
-    return thrust / mass
 end
 
 -- Draw the MFD every frame
@@ -489,15 +491,16 @@ local function auto_sequence(simt)
   elseif self.sequence==STATE.PRERETRO then
     ThrCommand=0.5
     if simt>self.simt_timer then
-      ThrMotor=1
-      self.sequence=STATE.RETRO_WAIT_FOR_THRUST
+        ThrMotor = 1
+        self.simt_timer=simt+20
+        self.sequence=STATE.RETRO
     end
-  elseif self.sequence==STATE.RETRO_WAIT_FOR_THRUST then
+  elseif self.sequence==STATE.RETRO then
       ThrCommand=0.5
-      if get_thr_acc() > 4.0 * 9.80665 then
-          self.sequence=STATE.RETRO_WAIT_FOR_BURNOUT
+      if simt>self.simt_timer then
+          self.sequence=STATE.RETRO_WATCH_FOR_BURNOUT
       end
-  elseif self.sequence==STATE.RETRO_WAIT_FOR_BURNOUT then
+  elseif self.sequence==STATE.RETRO_WATCH_FOR_BURNOUT then
       ThrCommand=0.5
       if get_thr_acc() < 3.5 * 9.80665 then
           self.sequence=STATE.RETRO_WAIT_FOR_JETTISON

--- a/Config/MFD/SLG.cfg
+++ b/Config/MFD/SLG.cfg
@@ -74,6 +74,7 @@ function buttonmenu()
 end
 
 local VERNIER_THRUST = 463
+local MAX_RETRO_THR=43757
 local AltMark=92000
 
 local DescentCurveSpd={ 1.5, 3, 30, 120,  210,  250};
@@ -89,11 +90,14 @@ local STATE={
   WAITING_FOR_ALT_MARK=1,
   WAITING_FOR_PRERETRO=2,
   PRERETRO=3,
-  RETRO=4,
-  DROP_TO_CURVE=5,
-  RIDE_CURVE=6,
-  CONSTANT_VEL=7,
-  DONE=8
+  RETRO_WAIT_FOR_THRUST=4,
+  RETRO_WAIT_FOR_BURNOUT = 5,
+  RETRO_WAIT_FOR_JETTISON = 6,
+  WAIT_FOR_DROP_TO_CURVE=7,
+  DROP_TO_CURVE=8,
+  RIDE_CURVE=9,
+  CONSTANT_VEL=10,
+  DONE=11,
 }
 
 local STATE_NAME={
@@ -101,7 +105,10 @@ local STATE_NAME={
   [STATE.WAITING_FOR_ALT_MARK]="Waiting for altitude mark",
   [STATE.WAITING_FOR_PRERETRO]="Have Alt Mark, waiting for preretro",
   [STATE.PRERETRO]            ="Pre-retro, starting verniers",
-  [STATE.RETRO]               ="Retro burn",
+  [STATE.RETRO_WAIT_FOR_THRUST]="Retro - wait for thrust >4g",
+  [STATE.RETRO_WAIT_FOR_BURNOUT] = "Retro - wait for thrust <3.5g",
+  [STATE.RETRO_WAIT_FOR_JETTISON] = "Retro - wait for jettison",
+  [STATE.WAIT_FOR_DROP_TO_CURVE]="Post-retro, stabilize",
   [STATE.DROP_TO_CURVE]       ="Drop to descent curve",
   [STATE.RIDE_CURVE]          ="Ride descent curve",
   [STATE.CONSTANT_VEL]        ="Constant velocity",
@@ -299,6 +306,13 @@ local function calc_impact()
 
 end
 
+local function get_thr_acc()
+    local mass = self.vi:get_mass()
+    local thrust = self.vi:get_thrustergrouplevel(THGROUP.MAIN) * 3 * VERNIER_THRUST +
+                   self.vi:get_thrustergrouplevel(THGROUP.HOVER) * MAX_RETRO_THR
+    return thrust / mass
+end
+
 -- Draw the MFD every frame
 ---callback
 function update(skp)
@@ -312,12 +326,13 @@ function update(skp)
 
   skp:text(cw*1, ch*2, "Slant Range:  "..eng_format(self.slant).."m")
   skp:text(cw*1, ch*3, "vspd:         "..eng_format(self.vel_b.z).."m/s")
-    
+  skp:text(cw*1, ch*4, "Thr acc:      "..eng_format(get_thr_acc()).."m/s")
+
   local Idx=TPIR(-self.vel_b.z)
   local DesiredAlt=nil
   if(Idx>=1) then
     DesiredAlt=linterp(DescentCurveSpd[Idx],DescentCurveAlt[Idx],DescentCurveSpd[Idx+1],DescentCurveAlt[Idx+1],-self.vel_b.z);
-    skp:text(cw*1, ch*4, "Alt Error:   "..eng_format(self.alt-DesiredAlt).."m")
+    skp:text(cw*1, ch*5, "Alt Error:   "..eng_format(self.alt-DesiredAlt).."m")
   else
     DesiredAlt=DescentCurveAlt[#DescentCurveSpd];
   end
@@ -443,17 +458,18 @@ local function steer_retro()
 end
 
 local function alt_on_descent_curve(spd)
-    local Idx=TPIR(spd);
-    local DesiredAlt=nil
-    if Idx>=0 then
-       DesiredAlt=linterp(DescentCurveSpd[Idx  ],DescentCurveAlt[Idx  ],
-                          DescentCurveSpd[Idx+1],DescentCurveAlt[Idx+1],
-                          spd);
+    local Idx = TPIR(spd);
+    local DesiredAlt = nil
+    if Idx >= 0 then
+        DesiredAlt = linterp(DescentCurveSpd[Idx], DescentCurveAlt[Idx],
+            DescentCurveSpd[Idx + 1], DescentCurveAlt[Idx + 1],
+            spd);
     else
-       DesiredAlt=DescentCurveAlt[#DescentCurveAlt];
+        DesiredAlt = DescentCurveAlt[#DescentCurveAlt];
     end
-    return DesiredAlt,Idx
+    return DesiredAlt, Idx
 end
+
 
 local function auto_sequence(simt)
   local ThrCommand=0
@@ -471,19 +487,35 @@ local function auto_sequence(simt)
       self.sequence=STATE.PRERETRO
     end
   elseif self.sequence==STATE.PRERETRO then
-    ThrCommand=0.8
+    ThrCommand=0.5
     if simt>self.simt_timer then
       ThrMotor=1
-      self.simt_timer=simt+41
-      self.sequence=STATE.RETRO
+      self.sequence=STATE.RETRO_WAIT_FOR_THRUST
     end
-  elseif self.sequence==STATE.RETRO then
-    ThrCommand=0.8
-    if simt>self.simt_timer then
-      self.sequence=STATE.DROP_TO_CURVE
-    end
+  elseif self.sequence==STATE.RETRO_WAIT_FOR_THRUST then
+      ThrCommand=0.5
+      if get_thr_acc() > 4.0 * 9.80665 then
+          self.sequence=STATE.RETRO_WAIT_FOR_BURNOUT
+      end
+  elseif self.sequence==STATE.RETRO_WAIT_FOR_BURNOUT then
+      ThrCommand=0.5
+      if get_thr_acc() < 3.5 * 9.80665 then
+          self.sequence=STATE.RETRO_WAIT_FOR_JETTISON
+          self.simt_timer=simt+12
+      end
+  elseif self.sequence==STATE.RETRO_WAIT_FOR_JETTISON then
+      ThrCommand=0.5
+      if simt>self.simt_timer then
+          self.simt_timer=simt+2.15
+          self.sequence=STATE.WAIT_FOR_DROP_TO_CURVE
+      end
+  elseif self.sequence==STATE.WAIT_FOR_DROP_TO_CURVE then
+      ThrCommand=1.0
+      if simt>self.simt_timer then
+          self.sequence=STATE.DROP_TO_CURVE
+      end
   elseif self.sequence==STATE.DROP_TO_CURVE then
-    --calculate vernier thrust to get 90%g (so downward acceleration is 10%g)
+        --calculate vernier thrust to get 90%g_m (so downward acceleration is 10%g_m)
     local mass=self.vi:get_mass();
     local DesiredAcc=0.9*self.g;
     local Thr=DesiredAcc*mass;

--- a/Config/Surveyor.cfg
+++ b/Config/Surveyor.cfg
@@ -118,7 +118,13 @@ local self              = {
     --thruster handles
     th_vernier = nil,
     th_rcs = nil,
-    th_retro=nil
+    th_retro = nil,
+    --retro case
+    retro_seen_up = false,
+    retro_seen_down = false,
+    simt_retro_jettison = nil,
+    --vehicle state
+    status=0,
 }
 
 
@@ -151,8 +157,8 @@ end
 -- helper function to create an iterator usable in a for loop
 local function iterate_lines(scn)
     return function()
-              return oapi.readscenario_nextline(scn)
-           end
+        return oapi.readscenario_nextline(scn)
+    end
 end
 
 --@callback
@@ -299,35 +305,51 @@ local function create_thrusters()
     end
 end
 
-local function calc_emptymass()
-  local empty_mass=LANDER_EMPTY_MASS
-  if vi:get_propellantmass(self.ph_retro)>0.999*RETRO_PROP_MASS then
-      empty_mass=empty_mass+AMR_MASS
-  end
-  if vi:get_propellantmass(self.ph_retro)>0.001*RETRO_PROP_MASS then
-      empty_mass=empty_mass+RETRO_EMPTY_MASS
-  end
-  return empty_mass
+local function calc_emptymass(simt)
+    local empty_mass = LANDER_EMPTY_MASS
+    if self.status<1 then
+        empty_mass = empty_mass + AMR_MASS
+    end
+    if self.status<2 then
+        empty_mass = empty_mass + RETRO_EMPTY_MASS
+    end
+    return empty_mass
+end
+
+local function setup_meshes()
+    vi:clear_meshes();
+    self.mLander = oapi.load_meshglobal("Surveyor/Surveyor-Lander");
+    self.mRetro = oapi.load_meshglobal("Surveyor/Surveyor-Retro");
+    self.mAMR = oapi.load_meshglobal("Surveyor/Surveyor-AMR");
+    vi:add_mesh(self.mLander)
+    if self.status < 2 then vi:add_mesh(self.mRetro) end
+    if self.status < 1 then vi:add_mesh(self.mAMR) end
+end
+
+local function jettison()
+    self.status = self.status + 1
+    setup_meshes()
 end
 
 --@callback
 function clbk_setclasscaps(cfg)
-  create_animations()
-  create_propellant()
-  create_thrusters()
+    create_animations()
+    create_propellant()
+    create_thrusters()
 
-  -- physical vessel parameters
-  vi:set_size(1.0)
-  
-  vi:set_pmi(_V(0.5,0.6,0.5))
-  vi:set_cameraoffset (_V(0,1,1))
-  vi:set_camerarotationrange(PI,PI,PI/2.0,PI/2.0)
+    -- physical vessel parameters
+    vi:set_size(1.0)
 
-  vi:set_touchdownpoints( _V( 0,LEG_RAD,LEG_STA), _V(-TRI32*LEG_RAD,-0.5*LEG_RAD,LEG_STA), _V(TRI32*LEG_RAD,-0.5*LEG_RAD,LEG_STA));
-  
+    vi:set_pmi(_V(0.5, 0.6, 0.5))
+    vi:set_cameraoffset(_V(0, 1, 1))
+    vi:set_camerarotationrange(PI, PI, PI / 2.0, PI / 2.0)
 
-  -- associate a mesh for the visual
-  vi:add_mesh('Surveyor-Lander')
+    vi:set_touchdownpoints(_V(0, LEG_RAD, LEG_STA), _V(-TRI32 * LEG_RAD, -0.5 * LEG_RAD, LEG_STA),
+        _V(TRI32 * LEG_RAD, -0.5 * LEG_RAD, LEG_STA));
+
+
+    -- associate a mesh for the visual
+    setup_meshes()
 end
 
 --@callback
@@ -412,33 +434,48 @@ local function srm(simt)
         self.simt_retro_t1=self.simt_retro_start+thrust_curve[i].t
         self.simt_retro_L1=thrust_curve[i].L
     end
-    if self.simt_retro_start==nil then
+    if self.simt_retro_start == nil then
         --check for ignition
         if vi:get_thrustergrouplevel(THGROUP.HOVER) > 0 then
             self.simt_retro_start = simt
             self.retro_current_seg = 2
             set_thr_segment()
+            jettison()
         end
     else
-        while simt>self.simt_retro_t1 and self.retro_current_seg<#thrust_curve do
+        while simt > self.simt_retro_t1 and self.retro_current_seg < #thrust_curve do
             self.retro_current_seg = self.retro_current_seg + 1
             set_thr_segment()
         end
-        if self.retro_current_seg==#thrust_curve then
-            vi:set_thrustergrouplevel(THGROUP.HOVER,0)
+        if self.retro_current_seg == #thrust_curve then
+            vi:set_thrustergrouplevel(THGROUP.HOVER, 0)
         else
-            local t=(simt-self.simt_retro_t0)/(self.simt_retro_t1-self.simt_retro_t0)
-            local L=(1-t)*self.simt_retro_L0+t*self.simt_retro_L1
-            vi:set_thrustergrouplevel(THGROUP.HOVER,L)
+            local t = (simt - self.simt_retro_t0) / (self.simt_retro_t1 - self.simt_retro_t0)
+            local L = (1 - t) * self.simt_retro_L0 + t * self.simt_retro_L1
+            vi:set_thrustergrouplevel(THGROUP.HOVER, L)
         end
-
+        local mass = vi:get_mass()
+        local thrust = 3 * VERNIER_THRUST * vi:get_thrustergrouplevel(THGROUP.MAIN) +
+            vi:get_thrustergrouplevel(THGROUP.HOVER) * max_retro_thr
+        local acc = thrust / mass
+        if not self.retro_seen_up and acc > 4 * 9.80665 then
+            self.retro_seen_up = true
+        end
+        if not self.retro_seen_down and self.retro_seen_up and acc < 3.5 * 9.80665 then
+            self.retro_seen_down = true
+            self.simt_retro_jettison = simt + 12
+        end
+        if self.simt_retro_jettison ~= nil and simt > self.simt_retro_jettison then
+            jettison()
+            vi:set_propellantmass(self.ph_retro,0)
+        end
     end
 end
 
 --@callback
 function clbk_prestep(simt, simdt, mjd)
     -- Animations
-    vi:set_emptymass(calc_emptymass())
+    vi:set_emptymass(calc_emptymass(simt))
 
     anim_status_propagate(self.gear_status, simdt)
     anim_status_propagate(self.ant_status, simdt)


### PR DESCRIPTION
Also update Surveyor spacecraft to automatically sequence the retro parts including their mass. This *should* be under the control of guidance, but in Orbiter with Lua, a guidance running in an MFD can't reach in and call methods of another Lua vessel.